### PR TITLE
kompute : enable kp_logger and make it static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,7 @@ if (LLAMA_KOMPUTE)
 
     if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/kompute/CMakeLists.txt")
         message(STATUS "Kompute found")
+        set(KOMPUTE_OPT_LOG_LEVEL Error CACHE STRING "Kompute log level")
         add_subdirectory(kompute)
 
         # Compile our shaders

--- a/kompute/src/logger/CMakeLists.txt
+++ b/kompute/src/logger/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 set(LOGGER_SOURCES Logger.cpp)
 
-add_library(kp_logger ${LOGGER_SOURCES})
+add_library(kp_logger STATIC ${LOGGER_SOURCES})
 
 # Define log levels in code
 add_compile_definitions(KOMPUTE_LOG_LEVEL_TRACE=0)


### PR DESCRIPTION
Fixes this error:
```
OSError: libkp_logger.so: cannot open shared object file: No such file or directory
```

This enables the 'Error' log level for internal builds of llama.cpp only. To enable it for gpt4all builds, we need to make a similar modification to llama.cpp.cmake.